### PR TITLE
Fixed setup on MySQL servers running in STRICT mode

### DIFF
--- a/install/create_db.php
+++ b/install/create_db.php
@@ -35,8 +35,8 @@ $_pdo->query("DROP TABLE IF EXISTS ".$db_prefix."pages", NULL, FALSE);
 $result = $_pdo->query("CREATE TABLE ".$db_prefix."pages (
 	`id` SMALLINT UNSIGNED AUTO_INCREMENT,
 	`title` VARCHAR(255) NOT NULL DEFAULT '',
-	`content` TEXT NOT NULL DEFAULT '',
-	`preview` MEDIUMTEXT NOT NULL DEFAULT '',
+	`content` TEXT NOT NULL,
+	`preview` MEDIUMTEXT NOT NULL,
 	`description` VARCHAR(255) NOT NULL DEFAULT '',
 	`type` SMALLINT UNSIGNED NOT NULL DEFAULT '0',
 	`categories` VARCHAR(255) NOT NULL DEFAULT '',
@@ -82,7 +82,7 @@ $_pdo->query("DROP TABLE IF EXISTS ".$db_prefix."pages_categories", NULL, FALSE)
 $result = $_pdo->query("CREATE TABLE ".$db_prefix."pages_categories (
 	`id` SMALLINT UNSIGNED AUTO_INCREMENT,
 	`name` VARCHAR(255) NOT NULL DEFAULT '',
-	`description` MEDIUMTEXT NOT NULL DEFAULT '',
+	`description` MEDIUMTEXT NOT NULL,
 	`submitting_groups` VARCHAR(255) NOT NULL DEFAULT '',
 	`thumbnail` VARCHAR(255) NOT NULL DEFAULT '',
 	`is_system` TINYINT UNSIGNED NOT NULL DEFAULT '0',
@@ -94,7 +94,7 @@ if ( ! $result) $fail = TRUE;
 $_pdo->query("DROP TABLE IF EXISTS ".$db_prefix."pages_custom_settings", NULL, FALSE);
 $result = $_pdo->query("CREATE TABLE ".$db_prefix."pages_custom_settings (
 	`id` SMALLINT UNSIGNED AUTO_INCREMENT,
-	`settings` MEDIUMTEXT NOT NULL DEFAULT '',
+	`settings` MEDIUMTEXT NOT NULL,
 	PRIMARY KEY (`id`)
 ) ENGINE = InnoDB CHARACTER SET ".$charset." COLLATE ".$collate.";", NULL, FALSE);
 if ( ! $result) $fail = TRUE;
@@ -377,7 +377,7 @@ $result = $_pdo->query("CREATE TABLE ".$db_prefix."user_fields (
 	`index` VARCHAR(50) NOT NULL,
 	`cat` MEDIUMINT UNSIGNED NOT NULL DEFAULT '1',
 	`type` SMALLINT NOT NULL DEFAULT '0',
-	`option` TEXT NOT NULL DEFAULT '',
+	`option` TEXT NOT NULL,
 	`register` TINYINT NOT NULL DEFAULT '0',
 	`hide` TINYINT NOT NULL DEFAULT '0',
 	`edit` TINYINT NOT NULL DEFAULT '0',
@@ -415,7 +415,7 @@ $result = $_pdo->query("CREATE TABLE ".$db_prefix."users (
 	`actiontime` INT UNSIGNED NOT NULL DEFAULT '0',
 	`theme` VARCHAR(100) NOT NULL DEFAULT 'Default',
 
-	`roles` TEXT NOT NULL DEFAULT '',
+	`roles` TEXT NOT NULL,
 	`role` INT(11) NOT NULL DEFAULT '2',
 	`lastupdate` INT NOT NULL DEFAULT '0',
 	`lang` VARCHAR(20) NOT NULL,
@@ -444,7 +444,7 @@ $result = $_pdo->query("CREATE TABLE ".$db_prefix."users_data (
   `skype` VARCHAR(200) NOT NULL DEFAULT '',
   `www` VARCHAR(200) NOT NULL DEFAULT '',
   `location` VARCHAR(200) NOT NULL DEFAULT '',
-  `sig` TEXT NOT NULL DEFAULT '',
+  `sig` TEXT NOT NULL,
   PRIMARY KEY (`user_id`)
 ) ENGINE = InnoDB CHARACTER SET ".$charset." COLLATE ".$collate.";", NULL, FALSE);
 if ( ! $result) $fail = TRUE;

--- a/install/create_settings.php
+++ b/install/create_settings.php
@@ -267,7 +267,7 @@ $_pdo->exec("INSERT INTO ".$_dbconfig['prefix']."news_cats (`name`, `link`, `ima
 $_pdo->exec("INSERT INTO ".$_dbconfig['prefix']."news_cats (`name`, `link`, `image`) VALUES ('Themes', '".HELP::Title2Link(__('Themes'))."', 'themes.png')");
 //$_pdo->exec("INSERT INTO ".$_dbconfig['prefix']."news_cats (`name`, `link`, `image`) VALUES ('Windows', '".HELP::Title2Link(__('Windows'))."', 'windows.png')");
 
-$_pdo->exec("INSERT INTO ".$_dbconfig['prefix']."news  (`id`, `title`, `link`, `category`, `content`, `author`, `source`, `breaks`, `description`, `datestamp`, `access`, `reads`, `draft`, `sticky`, `allow_comments`, `allow_ratings`, `language`) VALUES (NULL, '".__('Example news title')."', '".__('Example news url')."', '3', '".__('Example news content')."', '1', 'http://extreme-fusion.org', '0', '".__('Example news description')."', '".time()."', '3', '1', '0', '0', '1', '1', '".$_SESSION['localeset']."')");
+$_pdo->exec("INSERT INTO ".$_dbconfig['prefix']."news  (`id`, `title`, `link`, `category`, `content`, `author`, `source`, `breaks`, `description`, `datestamp`, `access`, `reads`, `draft`, `sticky`, `allow_comments`, `allow_ratings`, `language`, `content_extended`) VALUES (NULL, '".__('Example news title')."', '".__('Example news url')."', '3', '".__('Example news content')."', '1', 'http://extreme-fusion.org', '0', '".__('Example news description')."', '".time()."', '3', '1', '0', '0', '1', '1', '".$_SESSION['localeset']."', '')");
 
 $_pdo->exec("INSERT INTO ".$_dbconfig['prefix']."tags  (`id`, `supplement`, `supplement_id`, `value`, `value_for_link`, `access`) VALUES (1, 'NEWS', 1, 'eXtreme-Fusion', 'extreme_fusion', '1')");
 $_pdo->exec("INSERT INTO ".$_dbconfig['prefix']."tags  (`id`, `supplement`, `supplement_id`, `value`, `value_for_link`, `access`) VALUES (2, 'NEWS', 1, 'eXtreme-Fusion 5', 'extreme_fusion_5', '1')");
@@ -296,13 +296,13 @@ $_pdo->exec("INSERT INTO ".$_dbconfig['prefix']."user_field_cats (`name`, `order
 $_pdo->exec("INSERT INTO ".$_dbconfig['prefix']."user_field_cats (`name`, `order`) VALUES ('".__('Contact Information')."', 2)");
 $_pdo->exec("INSERT INTO ".$_dbconfig['prefix']."user_field_cats (`name`, `order`) VALUES ('".__('Miscellaneous')."', 3)");
 
-$_pdo->exec("INSERT INTO ".$_dbconfig['prefix']."user_fields (`name`, `index`, `cat`, `type`) VALUES ('".__('First name')."', 'name', 1, 1)");
-$_pdo->exec("INSERT INTO ".$_dbconfig['prefix']."user_fields (`name`, `index`, `cat`, `type`) VALUES ('".__('Date of birth')."', 'old', 1, 1)");
-$_pdo->exec("INSERT INTO ".$_dbconfig['prefix']."user_fields (`name`, `index`, `cat`, `type`) VALUES ('".__('Gadu-Gadu')."', 'gg', 2, 1)");
-$_pdo->exec("INSERT INTO ".$_dbconfig['prefix']."user_fields (`name`, `index`, `cat`, `type`) VALUES ('".__('Skype')."', 'skype', 2, 1)");
-$_pdo->exec("INSERT INTO ".$_dbconfig['prefix']."user_fields (`name`, `index`, `cat`, `type`) VALUES ('".__('Website')."', 'www', 2, 1)");
-$_pdo->exec("INSERT INTO ".$_dbconfig['prefix']."user_fields (`name`, `index`, `cat`, `type`) VALUES ('".__('Living place')."', 'location', 2, 1)");
-$_pdo->exec("INSERT INTO ".$_dbconfig['prefix']."user_fields (`name`, `index`, `cat`, `type`) VALUES ('".__('Signature')."', 'sig', 3, 2)");
+$_pdo->exec("INSERT INTO ".$_dbconfig['prefix']."user_fields (`name`, `index`, `cat`, `type`, `option`) VALUES ('".__('First name')."', 'name', 1, 1, '')");
+$_pdo->exec("INSERT INTO ".$_dbconfig['prefix']."user_fields (`name`, `index`, `cat`, `type`, `option`) VALUES ('".__('Date of birth')."', 'old', 1, 1, '')");
+$_pdo->exec("INSERT INTO ".$_dbconfig['prefix']."user_fields (`name`, `index`, `cat`, `type`, `option`) VALUES ('".__('Gadu-Gadu')."', 'gg', 2, 1, '')");
+$_pdo->exec("INSERT INTO ".$_dbconfig['prefix']."user_fields (`name`, `index`, `cat`, `type`, `option`) VALUES ('".__('Skype')."', 'skype', 2, 1, '')");
+$_pdo->exec("INSERT INTO ".$_dbconfig['prefix']."user_fields (`name`, `index`, `cat`, `type`, `option`) VALUES ('".__('Website')."', 'www', 2, 1, '')");
+$_pdo->exec("INSERT INTO ".$_dbconfig['prefix']."user_fields (`name`, `index`, `cat`, `type`, `option`) VALUES ('".__('Living place')."', 'location', 2, 1, '')");
+$_pdo->exec("INSERT INTO ".$_dbconfig['prefix']."user_fields (`name`, `index`, `cat`, `type`, `option`) VALUES ('".__('Signature')."', 'sig', 3, 2, '')");
 
 //$_pdo->exec("INSERT INTO ".$_dbconfig['prefix']."settings_inf (`name`, `value`, `inf`) VALUES ('version', '5.0', '(Beta)')");
 


### PR DESCRIPTION
My MySQL server is runing in strict mode and I got some errors when trying to run the setup. I fixed the db schema and queries for the setup but there might be more issues like that in the running application (which I didn't check yet).

These are my changes:
- TEXT columns mustn't have a default value - removed it from db schema
- added value '' to those columns in queries where needed
