### PR TITLE
Poprawka team.html

### DIFF
--- a/pages/team.php
+++ b/pages/team.php
@@ -45,7 +45,7 @@ $theme = array(
 define('THIS', TRUE);
 
 // Site Admin
-$row = $_pdo->getRow('SELECT * FROM [users] WHERE `id` = 1');
+$row = $_pdo->getRow('SELECT * FROM [users] WHERE `id` = 1 and `role` = 1');
 
 	if(time() <= $row['lastvisit']+300)
 	{


### PR DESCRIPTION
Do tej pory "Główny Administrator" wyświetlał się na podstronie team.php nawet gdy odebrano mu prawa administracyjne. Dodanie tego warunku zapewni sprawdzanie czy użytkownik o id=1 nadal ma uprawnienia administracyjne.
